### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # python-scim
 [![Build Status](https://travis-ci.org/concordusapps/python-scim.png?branch=master)](https://travis-ci.org/concordusapps/python-scim)
 [![Coverage Status](https://coveralls.io/repos/concordusapps/python-scim/badge.png?branch=master)](https://coveralls.io/r/concordusapps/python-scim?branch=master)
-[![PyPi Version](https://pypip.in/v/scim/badge.png)](https://pypi.python.org/pypi/scim)
-![PyPi Downloads](https://pypip.in/d/scim/badge.png)
+[![PyPi Version](https://img.shields.io/pypi/v/scim.svg)](https://pypi.python.org/pypi/scim)
+![PyPi Downloads](https://img.shields.io/pypi/dm/scim.svg)
 > A python interface to produce and consume System for Cross-domain Identity Management (SCIM) messages.
 
 ## Features


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20scim))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `scim`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.